### PR TITLE
solução alternativa para o bug do pgadmin

### DIFF
--- a/postgresql/postgresql_pgadmin/docker-compose.yaml
+++ b/postgresql/postgresql_pgadmin/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       PGADMIN_LISTEN_PORT: 80
     ports:
       - 8080:80
+    user: root
     volumes:
         - ./pgadmin-data:/var/lib/pgadmin
     links:


### PR DESCRIPTION
fix #2 
baseado nessas respostas:
https://stackoverflow.com/a/70351492
https://stackoverflow.com/a/48730146

resolver o problema de permissão de diretório simplesmente elevando a permissão mais alta, não deve ser o jeito mais seguro mas parece ser melhor do que realizar alguma operação no sistema host antes de executar o docker compose

procurei alguma informação explicando melhor essa propriedade e não achei